### PR TITLE
add mini chat-bot

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,90 @@
 import streamlit as st
 from components.simple_chatbot import show_simple_chatbot
+from dotenv import load_dotenv
+from langchain_core.prompts import ChatPromptTemplate, load_prompt
+from langchain_openai import ChatOpenAI
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.messages.chat import ChatMessage
 
 
 def main():
-    """
-    Streamlitアプリケーションのメイン処理を行う関数
-    """
-    st.title("シンプルなStreamlitアプリ")
+    load_dotenv()
 
-    show_simple_chatbot()
+    # 会話履歴にメッセージを追加する関数（ChatMessage形式で追加）
+    def add_history(role, content):
+        st.session_state.messages.append(ChatMessage(role=role, content=content))
 
-    st.write("---")
-    st.write("develop branch!")
+    # 会話履歴を画面に出力する関数
+    def print_history():
+        for msg in st.session_state["messages"]:
+            st.chat_message(msg.role).write(msg.content)
+
+    # プロンプトの種類によって、適切なチェーンを作成
+    def create_chain(prompt_type="基本"):
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "回答を簡潔にしてください。",
+                ),
+                ("user", "#Question:\n{question}"),
+            ]
+        )
+        if prompt_type == "SNS":
+            prompt = load_prompt("app/prompts/sns.yaml")
+        elif prompt_type == "まとめ":
+            prompt = load_prompt("app/prompts/summarize.yaml")
+
+        model = ChatOpenAI(model="gpt-4o-mini", temperature=0.1, streaming=True)
+
+        chain = prompt | model | StrOutputParser()
+        return chain
+
+    st.title("シンプルなStreamlit Chatアプリ")
+    st.info(
+        "このアプリは、StreamlitとLangChainを使用して構築されたシンプルなチャットボットです。"
+    )
+    # セッションステートに履歴がなければ初期化
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
+
+    # サイドバーのUI（会話履歴のクリアボタンとプロンプト種類の選択）
+    with st.sidebar:
+        clear_button = st.button("会話をクリア")
+        if clear_button:
+            st.session_state.messages = []
+
+        selected_option = st.selectbox(
+            "カテゴリーを選択してください",
+            ("基本", "SNS", "まとめ"),
+            index=0,
+            help="選択したカテゴリーに基づいて、AIの応答が変わります。",
+        )
+
+    print_history()
+    user_input = st.chat_input("질문을 입력하세요")
+    if user_input:
+        # ユーザーの入力を表示
+        st.chat_message("user").write(user_input)
+
+        # 選択されたカテゴリーに基づいてチェーンを作成
+        chain = create_chain(selected_option)
+
+        # AIの返答を格納する変数
+        ai_answer = ""
+        # AIの応答をストリームで受け取る
+        with st.spinner("AIが考えています..."):
+            response = chain.stream({"question": user_input})
+
+        with st.chat_message("assistant"):
+            container = st.empty()
+            for chunk in response:
+                ai_answer += chunk
+                container.markdown(ai_answer)
+
+        # 会話履歴にユーザーとAIのメッセージを追加（ChatMessage形式）
+        add_history("user", user_input)
+        add_history("assistant", ai_answer)
 
 
 if __name__ == "__main__":

--- a/app/prompts/sns.yaml
+++ b/app/prompts/sns.yaml
@@ -1,0 +1,10 @@
+_type: "prompt"
+template: |
+  あなたは20年のSNSマーケティングAIアシスタントです。ユーザーのリクエストに応じて適切なSNS投稿を作成してください。
+  必ず回答には絵文字を含めてください。回答の最後には適切なハッシュタグを含めてください。
+  
+  #Question:
+  {question}
+
+  #Answer:
+input_variables: ["question"]

--- a/app/prompts/summarize.yaml
+++ b/app/prompts/summarize.yaml
@@ -1,0 +1,9 @@
+_type: "prompt"
+template: |
+  あなたは20年の要約AIアシスタントです。ユーザーのリクエストに応じて適切な要約を作成してください。
+  
+  #Question:
+  {question}
+
+  #Answer:
+input_variables: ["question"]


### PR DESCRIPTION
## 関連チケット（チケットの URL を記載してください）

- (Streamitで簡単なアプリ作成)[https://www.notion.so/Streamit-1db407d21a3080c1aa08e0484320945f?pvs=4]

## 📝 概要

- LangChainとStreamitで簡単なアプリ作成

## 🔧 対応内容

- Open AIで簡単なチャットボットを作成した。
- カテゴリープロンプト別にチャットができるように実装。

## ❌ やっていなかったこと

- close #123

## 📸 スクリーンショット（UI 変更がある場合）

<img width="1781" alt="image" src="https://github.com/user-attachments/assets/3bae571a-0a26-4957-b046-e081d0ae8b41" />

## 🏃 動作確認
```
docker compose up --build
git checkout feature/mini-chat-project
```
`.env`ファイルにAPI Keyを用意して[loacalhost](http://localhost:8501/)でチャットボットを試す。

## ✅ チェックリスト

- [x] ローカルでの動作確認済み

## 📚 補足（あれば）

- 開発環境での確認手順や、注意点など
